### PR TITLE
update time related methods to be crystal 0.27.0 compatible

### DIFF
--- a/src/m3u8/time_item.cr
+++ b/src/m3u8/time_item.cr
@@ -45,7 +45,7 @@ module M3U8
     # item.empty? # => false
     # ```
     def empty?
-      @time.epoch.zero?
+      @time.to_unix.zero?
     end
 
     # ```
@@ -67,7 +67,7 @@ module M3U8
       case time
       when String then Time.iso8601(time)
       when Time   then time
-      else             Time.epoch 0
+      else             Time.unix 0
       end
     end
   end

--- a/src/patch/time.cr
+++ b/src/patch/time.cr
@@ -6,9 +6,9 @@ struct Time
 
   def self.iso8601(time : String)
     begin
-      parse(time, "%FT%T.%L%z").to_utc
+      parse!(time, "%FT%T.%L%z").to_utc
     rescue
-      parse(time, "%FT%T%z").to_utc
+      parse!(time, "%FT%T%z").to_utc
     end
   end
 end


### PR DESCRIPTION
`epoch` methods on Time were renamed. Also, `parse` now takes 3 arguments, but `parse!` only takes the 2. 